### PR TITLE
fix:correction in README, dump command output file is specified with -o not -b

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ picpro verify -p /dev/ttyUSB0 -i YOUR_HEX_FILE.hex -t 12F675
 ### Dump ROM as bin file
 
 ```bash
-picpro dump rom -p /dev/ttyUSB0 -b dump.rom -t 12F675
+picpro dump rom -p /dev/ttyUSB0 -o dump.rom -t 12F675
 ```
 
 ### Dump EEPROM as bin file
 
 ```bash
-picpro dump eeprom -p /dev/ttyUSB0 -b dump.eeprom -t 12F675
+picpro dump eeprom -p /dev/ttyUSB0 -o dump.eeprom -t 12F675
 ```
 
 ### Program chip via ISCP


### PR DESCRIPTION
Dump command expects output file name with option -o, example command is with -b