### PR TITLE
Added support for microcontrollers in 'chipdata.cid'.

### DIFF
--- a/usr/share/picpro/chipdata.cid
+++ b/usr/share/picpro/chipdata.cid
@@ -823,6 +823,30 @@ LIST3 FUSE1 "BODEN" "Enabled"=3FFF "Disabled"=3FBF
 LIST4 FUSE1 "Oscillator" "RC"=3FFF "HS"=3FFE "XT"=3FFD "LP"=3FFC
 LIST5 FUSE1 "Code Protect" "Disabled"=3FFF "CP50"=2AEF "CP75"=15DF "Enabled"=00CF
 
+CHIPname=16C66A
+INCLUDE=Y
+KITSRUS.COM=28Npin
+EraseMode=0
+FlashChip=N
+PowerSequence=VccVpp1
+ProgramDelay=1
+ProgramFlag2=25
+PanelSizing=3
+CoreType=bit14_A
+ROMsize=002000
+EEPROMsize=00000000
+FUSEblank=3FFF
+CPwarn=Y
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=FFFF
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FFB
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FF7
+LIST3 FUSE1 "BODEN" "Enabled"=3FFF "Disabled"=3FBF
+LIST4 FUSE1 "Oscillator" "RC"=3FFF "HS"=3FFE "XT"=3FFD "LP"=3FFC
+LIST5 FUSE1 "Code Protect" "Disabled"=3FFF "CP50"=2AEF "CP75"=15DF "Enabled"=00CF
+
 CHIPname=16C67
 INCLUDE=Y
 KITSRUS.COM=40pin
@@ -1468,6 +1492,29 @@ LIST3 FUSE1 "VBOR" "VBOR 25"=3FFF "VBOR 27"=3BFF "VBOR 42"=37FF "VBOR 45"=33FF
 LIST4 FUSE1 "Oscillator" "RC OSC"=3FFF "HS OSC"=3FFE "XT OSC"=3FFD "LP OSC"=3FFC
 LIST5 FUSE1 "Code Protect" "Disabled"=3FFF "CP50"=2EEF "CP75"=1DDF "Enabled"=0CCF
 
+CHIPname=16C83
+INCLUDE=Y
+KITSRUS.COM=18pin
+EraseMode=0
+FlashChip=Y
+PowerSequence=VccVpp2
+ProgramDelay=80
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_B
+ROMsize=000200
+EEPROMsize=00000040
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=FFFF
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FFB
+LIST2 FUSE1 "PWRTE" "Enabled"=3FFF "Disabled"=3FF7
+LIST3 FUSE1 "Oscillator" "RC"=3FFF "HS"=3FFE "XT"=3FFD "LP"=3FFC
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FEF
+
 CHIPname=16C84
 INCLUDE=Y
 KITSRUS.COM=18pin
@@ -1490,6 +1537,152 @@ LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FFB
 LIST2 FUSE1 "PWRTE" "Enabled"=3FFF "Disabled"=3FF7
 LIST3 FUSE1 "Oscillator" "RC"=3FFF "HS"=3FFE "XT"=3FFD "LP"=3FFC
 LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FEF
+
+CHIPname=16F505
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=6
+FlashChip=Y
+PowerSequence=VccVpp2
+ProgramDelay=20
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit12_A
+ROMsize=000400
+EEPROMsize=00000000
+FUSEblank=0FFF
+CPwarn=N
+CALword=Y
+BandGap=N
+ICSPonly=N
+ChipID=FFFF
+LIST1 FUSE1 "WDT" "Enabled"=0FFF "Disabled"=0FF7
+LIST2 FUSE1 "MCLRE" "Enabled"=0FFF "Disabled"=0FDF
+LIST3 FUSE1 "Oscillator" "EXRCCLK"=0FFF "EXRCRB4"=0FFE "INRCCLK"=0FFD "INRCRB4"=0FFC "HS"=0FFA "XT"=0FF9 "LP"=0FF8
+LIST4 FUSE1 "Code Protect" "Disabled"=0FFF "Enabled"=002F
+
+CHIPname=16F506
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=6
+FlashChip=Y
+PowerSequence=VccVpp2
+ProgramDelay=20
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit12_A
+ROMsize=000400
+EEPROMsize=00000000
+FUSEblank=0FFF
+CPwarn=N
+CALword=Y
+BandGap=N
+ICSPonly=N
+ChipID=FFFF
+LIST1 FUSE1 "WDT" "Enabled"=0FFF "Disabled"=0FF7
+LIST2 FUSE1 "MCLRE" "Enabled"=0FFF "Disabled"=0FDF
+LIST3 FUSE1 "Oscillator" "EXRCCLK"=0FFF "EXRCRB4"=0FFE "INRCCLK"=0FFD "INRCRB4"=0FFC "HS"=0FFA "XT"=0FF9 "LP"=0FF8
+LIST4 FUSE1 "Code Protect" "Disabled"=0FFF "Enabled"=002F
+LIST5 FUSE1 "IOSCFS " "8MHz OSC"=0FFF "4MHz OSC"=0F7F
+
+CHIPname=12F508
+INCLUDE=Y
+KITSRUS.COM=8pin
+EraseMode=6
+FlashChip=Y
+PowerSequence=VccVpp2
+ProgramDelay=20
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit12_A
+ROMsize=000200
+EEPROMsize=00000000
+FUSEblank=0FFF
+CPwarn=N
+CALword=Y
+BandGap=N
+ICSPonly=N
+ChipID=FFFF
+LIST1 FUSE1 "WDT" "Enabled"=0FFF "Disabled"=0FFB
+LIST2 FUSE1 "MCLRE" "Enabled"=0FFF "Disabled"=0FEF
+LIST3 FUSE1 "Oscillator" "EX_RC"=0FFF "IN_RC"=0FFE "XT"=0FFD "LP"=0FFC
+LIST4 FUSE1 "Code Protect" "Disabled"=0FFF "Enabled"=0FF7
+
+CHIPname=12F509
+INCLUDE=Y
+KITSRUS.COM=8pin
+EraseMode=6
+FlashChip=Y
+PowerSequence=VccVpp2
+ProgramDelay=20
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit12_A
+ROMsize=000400
+EEPROMsize=00000000
+FUSEblank=0FFF
+CPwarn=N
+CALword=Y
+BandGap=N
+ICSPonly=N
+ChipID=FFFF
+LIST1 FUSE1 "WDT" "Enabled"=0FFF "Disabled"=0FFB
+LIST2 FUSE1 "MCLRE" "Enabled"=0FFF "Disabled"=0FEF
+LIST3 FUSE1 "Oscillator" "EX_RC"=0FFF "IN_RC"=0FFE "XT"=0FFD "LP"=0FFC
+LIST4 FUSE1 "Code Protect" "Disabled"=0FFF "Enabled"=0FF7
+
+CHIPname=12F635
+INCLUDE=Y
+KITSRUS.COM=8pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=30
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_C
+ROMsize=00400
+EEPROMsize=00000080
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0FA0
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "WURE" "Enabled"=2FFF "Disabled"=3FFF
+LIST10 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FFB "HS"=3FFA "XT"=3FF9 "LP"=3FF8
+
+CHIPname=16F510
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=6
+FlashChip=Y
+PowerSequence=VccVpp2
+ProgramDelay=20
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit12_A
+ROMsize=000400
+EEPROMsize=00000000
+FUSEblank=0FFF
+CPwarn=N
+CALword=Y
+BandGap=N
+ICSPonly=N
+ChipID=FFFF
+LIST1 FUSE1 "WDT" "Enabled"=0FFF "Disabled"=0FF7
+LIST2 FUSE1 "MCLRE" "Enabled"=0FFF "Disabled"=0FDF
+LIST3 FUSE1 "Oscillator" "EXRCCLK"=0FFF "EXRCRB4"=0FFE "INRCCLK"=0FFD "INRCRB4"=0FFC "HS"=0FFA "XT"=0FF9 "LP"=0FF8
+LIST4 FUSE1 "Code Protect" "Disabled"=0FFF "Enabled"=002F
+LIST5 FUSE1 "IOSCFS " "8MHz OSC"=0FFF "4MHz OSC"=0F7F
 
 CHIPname=16F54
 INCLUDE=Y
@@ -1716,6 +1909,150 @@ LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
 LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
 LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FEF "HS"=3FEE "XT"=3FED "LP"=3FEC
 
+CHIPname=16F631-I
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=50
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_B
+ROMsize=000400
+EEPROMsize=00000080
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=1420
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FEF "HS"=3FEE "XT"=3FED "LP"=3FEC
+
+CHIPname=16F636
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=30
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_C
+ROMsize=00800
+EEPROMsize=00000100
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=10A0
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "WURE" "Enabled"=2FFF "Disabled"=3FFF
+LIST10 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FFB "HS"=3FFA "XT"=3FF9 "LP"=3FF8
+
+CHIPname=16F636-I
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=30
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_C
+ROMsize=00400
+EEPROMsize=00000080
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=10A0
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "WURE" "Enabled"=2FFF "Disabled"=3FFF
+LIST10 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FFB "HS"=3FFA "XT"=3FF9 "LP"=3FF8
+
+CHIPname=16F639
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=30
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_C
+ROMsize=00400
+EEPROMsize=00000080
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=10A0
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "WURE" "Enabled"=2FFF "Disabled"=3FFF
+LIST10 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FFB "HS"=3FFA "XT"=3FF9 "LP"=3FF8
+
+CHIPname=16F639-I
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=30
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_C
+ROMsize=00400
+EEPROMsize=00000080
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=10A0
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "WURE" "Enabled"=2FFF "Disabled"=3FFF
+LIST10 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FFB "HS"=3FFA "XT"=3FF9 "LP"=3FF8
+
 CHIPname=16F648A
 INCLUDE=Y
 KITSRUS.COM=18pin
@@ -1798,6 +2135,34 @@ LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
 LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
 LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FFB "HS"=3FFA "XT"=3FF9 "LP"=3FF8
 
+CHIPname=16F677-I
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=50
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_B
+ROMsize=001000
+EEPROMsize=00000100
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=1440
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FEF "HS"=3FEE "XT"=3FED "LP"=3FEC
+
 CHIPname=16F684
 INCLUDE=Y
 KITSRUS.COM=14pin
@@ -1854,6 +2219,34 @@ LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
 LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
 LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FEF "HS"=3FEE "XT"=3FED "LP"=3FEC
 
+CHIPname=16F685-I
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=50
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_B
+ROMsize=001000
+EEPROMsize=00000100
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=04A0
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FEF "HS"=3FEE "XT"=3FED "LP"=3FEC
+
 CHIPname=16F687
 INCLUDE=Y
 KITSRUS.COM=14pin
@@ -1871,6 +2264,34 @@ CPwarn=N
 CALword=N
 BandGap=N
 ICSPonly=N
+ChipID=1320
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FEF "HS"=3FEE "XT"=3FED "LP"=3FEC
+
+CHIPname=16F687-I
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=50
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_B
+ROMsize=000800
+EEPROMsize=00000100
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
 ChipID=1320
 LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
 LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
@@ -1938,6 +2359,34 @@ LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
 LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
 LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FFB "HS"=3FFA "XT"=3FF9 "LP"=3FF8
 
+CHIPname=16F689-I
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=50
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_B
+ROMsize=001000
+EEPROMsize=00000100
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=1340
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FEF "HS"=3FEE "XT"=3FED "LP"=3FEC
+
 CHIPname=16F690
 INCLUDE=Y
 KITSRUS.COM=14pin
@@ -1965,6 +2414,59 @@ LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"
 LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
 LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
 LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FFB "HS"=3FFA "XT"=3FF9 "LP"=3FF8
+
+CHIPname=16F690-I
+INCLUDE=Y
+KITSRUS.COM=14pin
+EraseMode=2
+FlashChip=Y
+PowerSequence=Vpp2Vcc
+ProgramDelay=50
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_B
+ROMsize=001000
+EEPROMsize=00000100
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=1400
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FF7
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FEF
+LIST3 FUSE1 "MCLRE" "Enabled"=3FFF "Disabled"=3FDF
+LIST4 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=3FBF
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3F7F
+LIST6 FUSE1 "BODEN" "BODon SBODENoff"=3FFF "BODrun SBODENoff"=3EFF "SBODEN=PCON"=3DFF "BODoff SBODENoff"=3CFF
+LIST7 FUSE1 "InEx Switch Over" "Enabled"=3FFF "Disabled"=3BFF
+LIST8 FUSE1 "Fail Clock Mon" "Enabled"=3FFF "Disabled"=37FF
+LIST9 FUSE1 "Oscillator" "EXTRC_CLKOUT"=3FFF "EXTRC_IO"=3FFE "INTRC_CLKOUT"=3FFD "INTRC_IO"=3FFC "EC"=3FEF "HS"=3FEE "XT"=3FED "LP"=3FEC
+
+CHIPname=16F716
+INCLUDE=Y
+KITSRUS.COM=18pin
+EraseMode=1
+FlashChip=Y
+PowerSequence=VccVpp2
+ProgramDelay=20
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_B
+ROMsize=000800
+EEPROMsize=00000000
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=1140
+LIST1 FUSE1 "WDT" "ON"=3FFF "OFF"=3FFB
+LIST2 FUSE1 "PWRTE" "OFF"=3FFF "ON"=3FF7
+LIST3 FUSE1 "BOREN" "ON"=3FFF "OFF"=3FBF
+LIST4 FUSE1 "BORV" "4.0V"=3FFF "2.5V"=3F7F
+LIST5 FUSE1 "Oscillator" "RC"=3FFF "LP"=3FFC "XT"=3FFD "HS"=3FFE
+LIST6 FUSE1 "Code Protect" "OFF"=3FFF "ON"=1FFF
 
 CHIPname=16F72
 INCLUDE=Y
@@ -2508,6 +3010,34 @@ LIST8 FUSE1 "Oscillator" "RC"=3FFF "HS"=3FFE "XT"=3FFD "LP"=3FFC
 LIST9 FUSE1 "Code Protect" "Disabled"=3FFF "HALF"=2FEF "UPPER-256"=1FDF "ALL"=0FCF
 
 CHIPname=16F873A
+INCLUDE=Y
+KITSRUS.COM=28Npin
+EraseMode=5
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit14_E
+ROMsize=001000
+EEPROMsize=00000080
+FUSEblank=3FFF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0E40
+LIST1 FUSE1 "WDT" "Enabled"=3FFF "Disabled"=3FFB
+LIST2 FUSE1 "PWRTE" "Disabled"=3FFF "Enabled"=3FF7
+LIST3 FUSE1 "BODEN" "Enabled"=3FFF "Disabled"=3FBF
+LIST4 FUSE1 "LVP" "Enabled"=3FFF "Disabled"=3F7F
+LIST5 FUSE1 "CPD" "Disabled"=3FFF "Enabled"=3EFF
+LIST6 FUSE1 "WRT Enable" "Enabled"=3FFF "WRT_256"=3DFF "WRT_1FOURTH"=3BFF "WRT_HALF"=39FF
+LIST7 FUSE1 "DEBUG" "Disabled"=3FFF "Enabled"=37FF
+LIST8 FUSE1 "Oscillator" "RC"=3FFF "HS"=3FFE "XT"=3FFD "LP"=3FFC
+LIST9 FUSE1 "Code Protect" "Disabled"=3FFF "Enabled"=1FFF
+
+CHIPname=16LF873A
 INCLUDE=Y
 KITSRUS.COM=28Npin
 EraseMode=5
@@ -3859,6 +4389,57 @@ LIST31 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ En
 LIST32 FUSE7 "ROM Table Read Protect" "BBSIZ-1FFF Disabled"=FFFF "BBSIZ-1FFF Enabled"=FFFE
 LIST33 FUSE7 "ROM Table Read Protect" "2000-3FFF Disabled"=FFFF "2000-3FFF Enabled"=FFFD
 
+CHIPname=18F2515
+INCLUDE=Y
+KITSRUS.COM=28Npin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=006000
+EEPROMsize=00000000
+FUSEblank=CF00 1F1F 8700 00C5 C007 E007 4007 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0CE0
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "2K words"=FFFF "1K words"=FEFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST23 FUSE6 "BOOT Table Write Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST24 FUSE6 "ROM Table Write Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST25 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST27 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST28 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST29 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST30 FUSE7 "ROM Table Read Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST31 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST32 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+
 CHIPname=18F2520
 INCLUDE=Y
 KITSRUS.COM=28Npin
@@ -3910,6 +4491,57 @@ LIST30 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
 LIST31 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
 LIST32 FUSE7 "ROM Table Read Protect" "BBSIZ-1FFF Disabled"=FFFF "BBSIZ-1FFF Enabled"=FFFE
 LIST33 FUSE7 "ROM Table Read Protect" "2000-3FFF Disabled"=FFFF "2000-3FFF Enabled"=FFFD
+
+CHIPname=18F2525
+INCLUDE=Y
+KITSRUS.COM=28Npin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=006000
+EEPROMsize=00000100
+FUSEblank=CF00 1F1F 8700 00C5 C007 E007 4007 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0CC0
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "2K words"=FFFF "1K words"=FEFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST23 FUSE6 "BOOT Table Write Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST24 FUSE6 "ROM Table Write Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST25 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST27 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST28 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST29 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST30 FUSE7 "ROM Table Read Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST31 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST32 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
 
 CHIPname=18F2550
 INCLUDE=Y
@@ -4016,6 +4648,216 @@ LIST31 FUSE7 "ROM Table Read Protect" "BBSIZ-1FFF Disabled"=FFFF "BBSIZ-1FFF Ena
 LIST32 FUSE7 "ROM Table Read Protect" "2000-3FFF Disabled"=FFFF "2000-3FFF Enabled"=FFFD
 LIST33 FUSE7 "ROM Table Read Protect" "4000-5FFF Disabled"=FFFF "4000-5FFF Enabled"=FFFB
 LIST34 FUSE7 "ROM Table Read Protect" "6000-7FFF Disabled"=FFFF "6000-7FFF Enabled"=FFF7
+
+CHIPname=18F2585
+INCLUDE=Y
+KITSRUS.COM=28Npin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=006000
+EEPROMsize=00000100
+FUSEblank=CF00 1F1F 8600 00F5 C007 E007 4007 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0EE0
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "4K words"=FFFF "2K words"=FDFF "1K words"=FCFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST23 FUSE6 "BOOT Table Write Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST24 FUSE6 "ROM Table Write Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST25 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST27 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST28 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST29 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST30 FUSE7 "ROM Table Read Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST31 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST32 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+
+CHIPname=18F2610
+INCLUDE=Y
+KITSRUS.COM=28Npin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000000
+FUSEblank=CF00 1F1F 8700 00C5 C00F E00F 400F 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0CA0
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "2K words"=FFFF "1K words"=FEFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "0400-7FFF Disabled"=FFFF "0400-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-7FFF Enabled"=FFF7
+LIST23 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST24 FUSE6 "BOOT Table Write Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST25 FUSE6 "ROM Table Write Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST26 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST27 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=F7FB
+LIST28 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST29 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST30 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST31 FUSE7 "BOOT Table Read Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST32 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST33 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST34 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFD
+
+CHIPname=18F2620
+INCLUDE=Y
+KITSRUS.COM=28Npin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000100
+FUSEblank=CF00 1F1F 8700 00C5 C00F E00F 400F 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0C80
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "2K words"=FFFF "1K words"=FEFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "0400-7FFF Disabled"=FFFF "0400-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-7FFF Enabled"=FFF7
+LIST23 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST24 FUSE6 "BOOT Table Write Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST25 FUSE6 "ROM Table Write Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST26 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST27 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=F7FB
+LIST28 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST29 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST30 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST31 FUSE7 "BOOT Table Read Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST32 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST33 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST34 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFD
+
+CHIPname=18F2680
+INCLUDE=Y
+KITSRUS.COM=28Npin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000100
+FUSEblank=CF00 1F1F 8600 00F5 C00F E00F 400F 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0EC0
+LIST1 FUSE1 "Osc Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.1V"=FFFF "2.8V"=FFF7 "4.3V"=FFFD "4.6V"=FFF9
+LIST5 FUSE2 "Brownout Reset" "HW only"=FFFF "HW but not sleep"=FFFB "Enabled under SW ctrl"=FFFD "Disabled"=FFF0
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "High Pwr Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Reset=Analog"=FFFF "AD 4:0 Reset=Digital"=FDFF
+LIST12 FUSE4 "BBSIZ" "4K words"=FFFF "2K words"=FDFF "1K words"=FCFF
+LIST13 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST14 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST15 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST16 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST17 FUSE5 "BOOT ROM Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST18 FUSE5 "ROM Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST19 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST20 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST21 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST22 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST23 FUSE6 "BOOT Table Write Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST24 FUSE6 "ROM Table Write Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST25 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=F7FB
+LIST27 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST28 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST29 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST30 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST31 FUSE7 "ROM Table Read Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST32 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST33 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST34 FUSE7 "ROM Table Read Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
 
 CHIPname=18F4220
 INCLUDE=Y
@@ -4615,6 +5457,57 @@ LIST31 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ En
 LIST32 FUSE7 "ROM Table Read Protect" "BBSIZ-1FFF Disabled"=FFFF "BBSIZ-1FFF Enabled"=FFFE
 LIST33 FUSE7 "ROM Table Read Protect" "2000-3FFF Disabled"=FFFF "2000-3FFF Enabled"=FFFD
 
+CHIPname=18F4515
+INCLUDE=Y
+KITSRUS.COM=40pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=006000
+EEPROMsize=00000000
+FUSEblank=CF00 1F1F 8700 00C5 C007 E007 4007 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0C60
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "2K words"=FFFF "1K words"=FEFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST23 FUSE6 "BOOT Table Write Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST24 FUSE6 "ROM Table Write Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST25 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST27 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST28 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST29 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST30 FUSE7 "ROM Table Read Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST31 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST32 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+
 CHIPname=18F4520
 INCLUDE=Y
 KITSRUS.COM=40pin
@@ -4666,6 +5559,57 @@ LIST30 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
 LIST31 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
 LIST32 FUSE7 "ROM Table Read Protect" "BBSIZ-1FFF Disabled"=FFFF "BBSIZ-1FFF Enabled"=FFFE
 LIST33 FUSE7 "ROM Table Read Protect" "2000-3FFF Disabled"=FFFF "2000-3FFF Enabled"=FFFD
+
+CHIPname=18F4525
+INCLUDE=Y
+KITSRUS.COM=40pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=006000
+EEPROMsize=00000100
+FUSEblank=CF00 1F1F 8700 00C5 C007 E007 4007 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0C40
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "2K words"=FFFF "1K words"=FEFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST23 FUSE6 "BOOT Table Write Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST24 FUSE6 "ROM Table Write Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST25 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST27 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST28 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST29 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST30 FUSE7 "ROM Table Read Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST31 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST32 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
 
 CHIPname=18F4550
 INCLUDE=Y
@@ -4773,6 +5717,216 @@ LIST32 FUSE7 "ROM Table Read Protect" "2000-3FFF Disabled"=FFFF "2000-3FFF Enabl
 LIST33 FUSE7 "ROM Table Read Protect" "4000-5FFF Disabled"=FFFF "4000-5FFF Enabled"=FFFB
 LIST34 FUSE7 "ROM Table Read Protect" "6000-7FFF Disabled"=FFFF "6000-7FFF Enabled"=FFF7
 
+CHIPname=18F4585
+INCLUDE=Y
+KITSRUS.COM=40pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=006000
+EEPROMsize=00000100
+FUSEblank=CF00 1F1F 8600 00F5 C007 E007 4007 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0EA0
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "4K words"=FFFF "2K words"=FDFF "1K words"=FCFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST23 FUSE6 "BOOT Table Write Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST24 FUSE6 "ROM Table Write Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST25 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST27 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST28 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST29 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST30 FUSE7 "ROM Table Read Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST31 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST32 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+
+CHIPname=18F4610
+INCLUDE=Y
+KITSRUS.COM=40pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000000
+FUSEblank=CF00 1F1F 8700 00C5 C00F E00F 400F 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0C20
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "2K words"=FFFF "1K words"=FEFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "0400-7FFF Disabled"=FFFF "0400-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-7FFF Enabled"=FFF7
+LIST23 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST24 FUSE6 "BOOT Table Write Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST25 FUSE6 "ROM Table Write Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST26 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST27 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=F7FB
+LIST28 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST29 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST30 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST31 FUSE7 "BOOT Table Read Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST32 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST33 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST34 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFD
+
+CHIPname=18F4620
+INCLUDE=Y
+KITSRUS.COM=40pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000100
+FUSEblank=CF00 1F1F 8700 00C5 C00F E00F 400F 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0C00
+LIST1 FUSE1 "IE Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail Safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST5 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "HighPower Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Analog on Reset"=FFFF "AD 4:0 Digital on Reset"=FDFF
+LIST12 FUSE3 "CCP2MX" "MUC RC1"=FFFF "MUC RE7/RB3"=FEFF
+LIST13 FUSE4 "BBSIZ" "2K words"=FFFF "1K words"=FEFF
+LIST14 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST15 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST16 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST17 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST18 FUSE5 "BOOT ROM Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST19 FUSE5 "ROM Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "0400-7FFF Disabled"=FFFF "0400-7FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-7FFF Enabled"=FFF7
+LIST23 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST24 FUSE6 "BOOT Table Write Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST25 FUSE6 "ROM Table Write Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST26 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST27 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=F7FB
+LIST28 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST29 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST30 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST31 FUSE7 "BOOT Table Read Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST32 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST33 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST34 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFD
+
+CHIPname=18F4680
+INCLUDE=Y
+KITSRUS.COM=40pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000100
+FUSEblank=CF00 1F1F 8600 00F5 C00F E00F 400F 
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0E80
+LIST1 FUSE1 "Osc Switchover" "Enabled"=FFFF "Disabled"=7FFF
+LIST2 FUSE1 "Fail safe Clock Mon" "Enabled"=FFFF "Disabled"=BFFF
+LIST3 FUSE1 "Oscillator" "LP Osc"=F0FF "XT Osc"=F1FF "HS Osc"=F2FF "Ext RC"=F3FF "EC Osc"=F4FF "EC Port RA6"=F5FF "HSPLL"=F6FF "Ext RC"=F7FF "Int OSC"=F8FF "Int OSC Clk RA6 PortB"=F9FF "Int Osc Clk RA6"=FBFF "Int Osc Clk RA6"=FCFF
+LIST4 FUSE2 "Brownout Voltage" "2.1V"=FFFF "2.8V"=FFF7 "4.3V"=FFFD "4.6V"=FFF9
+LIST5 FUSE2 "Brownout Reset" "HW only"=FFFF "HW but not sleep"=FFFB "Enabled under SW ctrl"=FFFD "Disabled"=FFF0
+LIST6 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST9 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST10 FUSE3 "LPT1OSC" "LOW Power Mode"=FFFF "High Pwr Mode"=FBFF
+LIST11 FUSE3 "PBADEN" "AD 4:0 Reset=Analog"=FFFF "AD 4:0 Reset=Digital"=FDFF
+LIST12 FUSE4 "BBSIZ" "4K words"=FFFF "2K words"=FDFF "1K words"=FCFF
+LIST13 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST14 FUSE4 "XINST" "Enabled"=FFFF "Disabled"=FFBF
+LIST15 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST16 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST17 FUSE5 "BOOT ROM Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST18 FUSE5 "ROM Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST19 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST20 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST21 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST22 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST23 FUSE6 "BOOT Table Write Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST24 FUSE6 "ROM Table Write Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST25 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=F7FB
+LIST27 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST28 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST29 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST30 FUSE7 "BOOT Table Read Protect" "0000-BBSIZ Disabled"=FFFF "0000-BBSIZ Enabled"=BFFF
+LIST31 FUSE7 "ROM Table Read Protect" "BBSIZ-3FFF Disabled"=FFFF "BBSIZ-3FFF Enabled"=FFFE
+LIST32 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST33 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST34 FUSE7 "ROM Table Read Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+
 CHIPname=18F6520
 INCLUDE=Y
 KITSRUS.COM=0pin
@@ -4869,6 +6023,99 @@ LIST27 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabl
 LIST28 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
 LIST29 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
 
+CHIPname=18F6585
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000100
+FUSEblank=2F00 1F0F 8383 0085 C00F E00F 400F
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=0A60
+LIST1 FUSE1 "OSCSEN" "Disabled"=FFFF "Enabled"=DFFF
+LIST2 FUSE1 "Oscillator" "RC OSC2 RA6"=FFFF "HS PLL"=FEFF "EC OSC2RA6"=FDFF "EC OSC2RA6 PLL"= FCFF "RC OSC2RA6"=F7FF "HS PLL"=F6FF "EC OSC2RA6"=F5FF "EC OSC2/4"=F4FF "RC OSC2/4"=F3FF "HS"=F2FF "XT"=F1FF "LP"=F0FF
+LIST3 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST4 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST5 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST6 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST7 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST8 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST9 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST10 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST11 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST12 FUSE5 "BOOT ROM Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST13 FUSE5 "ROM Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST14 FUSE5 "ROM Protect" "0400-7FFF Disabled"=FFFF "0400-7FFF Enabled"=FFFD
+LIST15 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST16 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST17 FUSE6 "BOOT Table Write Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST18 FUSE6 "ROM Table Write Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST19 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST20 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=17FB
+LIST21 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST22 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST23 FUSE7 "BOOT Table Read Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST24 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST25 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+
+CHIPname=18F6620
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=004000
+EEPROMsize=00000100
+FUSEblank=2700 0F0F 0183 0085 C0FF E0FF 40FF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0660
+LIST1 FUSE1 "Oscillator Enable" "Disabled"=FFFF "Enabled"=DFFF
+LIST2 FUSE1 "Oscillator" "RCO2RA6"=FFFF "HSPLL"=FEFF "ECO2RA6"=FDFF "ECO2 CLK Out"=FCFF "RC"=FBFF "HS"=FAFF "XT"=F9FF "LP"=F8FF
+LIST3 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST4 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST5 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST6 FUSE2 "Watchdog Postscale" "1:128"=FFFF "1:64"=FDFF "1:32"=FBFF "1:16"=F9FF "1:8"=F7FF "1:4"=F5FF "1:2"=F3FF "1:1"=F1FF
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE3 "CCP2 Mux" "Enabled"=FFFF "Disabled"=FEFF
+LIST9 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST10 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST11 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST12 FUSE5 "BOOT ROM Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST13 FUSE5 "ROM Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST14 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST15 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST16 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST17 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST18 FUSE6 "BOOT Table Write Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST19 FUSE6 "ROM Table Write Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST20 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST21 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST23 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST24 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST25 FUSE7 "BOOT Table Read Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST26 FUSE7 "ROM Table Read Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST27 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST28 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST29 FUSE7 "ROM Table Read Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+
 CHIPname=18F6621
 INCLUDE=Y
 KITSRUS.COM=0pin
@@ -4919,6 +6166,107 @@ LIST29 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabl
 LIST30 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
 LIST31 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
 LIST32 FUSE7 "ROM Table Read Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+
+CHIPname=18F6680
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000100
+FUSEblank=2F00 1F0F 8383 0085 C00F E00F 400F
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=0A20
+LIST1 FUSE1 "OSCSEN" "Disabled"=FFFF "Enabled"=DFFF
+LIST2 FUSE1 "Oscillator" "RC OSC2 RA6"=FFFF "HS PLL"=FEFF "EC OSC2RA6"=FDFF "EC OSC2RA6 PLL"= FCFF "RC OSC2RA6"=F7FF "HS PLL"=F6FF "EC OSC2RA6"=F5FF "EC OSC2/4"=F4FF "RC OSC2/4"=F3FF "HS"=F2FF "XT"=F1FF "LP"=F0FF
+LIST3 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST4 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST5 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST6 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST7 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST8 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST9 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST10 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST11 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST12 FUSE5 "BOOT ROM Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST13 FUSE5 "ROM Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST14 FUSE5 "ROM Protect" "0400-7FFF Disabled"=FFFF "0400-7FFF Enabled"=FFFD
+LIST15 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST16 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-7FFF Enabled"=FFF7
+LIST17 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST18 FUSE6 "BOOT Table Write Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST19 FUSE6 "ROM Table Write Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST20 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST21 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=17FB
+LIST22 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=1FF7
+LIST23 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST24 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST25 FUSE7 "BOOT Table Read Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST26 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST27 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST28 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST29 FUSE7 "ROM Table Read Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+
+CHIPname=18F6720
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=004000
+EEPROMsize=00000100
+FUSEblank=2700 0F0F 0183 0085 C0FF E0FF 40FF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=0620
+LIST1 FUSE1 "Oscillator Enable" "Disabled"=FFFF "Enabled"=DFFF
+LIST2 FUSE1 "Oscillator" "RCO2RA6"=FFFF "HSPLL"=FEFF "ECO2RA6"=FDFF "ECO2 CLK Out"=FCFF "RC"=FBFF "HS"=FAFF "XT"=F9FF "LP"=F8FF
+LIST3 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST4 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST5 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST6 FUSE2 "Watchdog Postscale" "1:128"=FFFF "1:64"=FDFF "1:32"=FBFF "1:16"=F9FF "1:8"=F7FF "1:4"=F5FF "1:2"=F3FF "1:1"=F1FF
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE3 "CCP2 Mux" "Enabled"=FFFF "Disabled"=FEFF
+LIST9 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST10 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST11 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST12 FUSE5 "BOOT ROM Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST13 FUSE5 "ROM Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST14 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST15 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST16 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST17 FUSE5 "ROM Protect" "10000-13FFF Disabled"=FFFF "10000-13FFF Enabled"=FFFE
+LIST18 FUSE5 "ROM Protect" "14000-17FFF Disabled"=FFFF "14000-17FFF Enabled"=FFFD
+LIST19 FUSE5 "ROM Protect" "18000-1BFFF Disabled"=FFFF "18000-1BFFF Enabled"=FFFB
+LIST20 FUSE5 "ROM Protect" "1C000-1FFFF Disabled"=FFFF "1C000-1FFFF Enabled"=FFF7
+LIST21 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST22 FUSE6 "BOOT Table Write Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST23 FUSE6 "ROM Table Write Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST24 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST25 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST26 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST27 FUSE6 "ROM Table Write Protect" "10000-13FFF Disabled"=FFFF "10000-13FFF Enabled"=FFFE
+LIST28 FUSE6 "ROM Table Write Protect" "14000-17FFF Disabled"=FFFF "14000-17FFF Enabled"=FFFD
+LIST29 FUSE6 "ROM Table Write Protect" "18000-1BFFF Disabled"=FFFF "18000-1BFFF Enabled"=FFFB
+LIST30 FUSE6 "ROM Table Write Protect" "1C000-1FFFF Disabled"=FFFF "1C000-1FFFF Enabled"=FFF7
+LIST31 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST32 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST33 FUSE7 "BOOT Table Read Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST34 FUSE7 "ROM Table Read Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
 
 CHIPname=18F8520
 INCLUDE=Y
@@ -5020,6 +6368,99 @@ LIST28 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabl
 LIST29 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
 LIST30 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
 
+CHIPname=18F8585
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000100
+FUSEblank=2F00 1F0F 8383 0085 C00F E00F 400F
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=0A40
+LIST1 FUSE1 "OSCSEN" "Disabled"=FFFF "Enabled"=DFFF
+LIST2 FUSE1 "Oscillator" "RC OSC2 RA6"=FFFF "HS PLL"=FEFF "EC OSC2RA6"=FDFF "EC OSC2RA6 PLL"= FCFF "RC OSC2RA6"=F7FF "HS PLL"=F6FF "EC OSC2RA6"=F5FF "EC OSC2/4"=F4FF "RC OSC2/4"=F3FF "HS"=F2FF "XT"=F1FF "LP"=F0FF
+LIST3 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST4 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST5 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST6 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST7 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST8 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST9 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST10 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST11 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST12 FUSE5 "BOOT ROM Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST13 FUSE5 "ROM Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST14 FUSE5 "ROM Protect" "0400-7FFF Disabled"=FFFF "0400-7FFF Enabled"=FFFD
+LIST15 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST16 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST17 FUSE6 "BOOT Table Write Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST18 FUSE6 "ROM Table Write Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST19 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST20 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=17FB
+LIST21 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST22 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST23 FUSE7 "BOOT Table Read Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST24 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST25 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST26 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+
+CHIPname=18F8620
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=004000
+EEPROMsize=00000100
+FUSEblank=2700 0F0F 0183 0085 C0FF E0FF 40FF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=N
+ChipID=0640
+LIST1 FUSE1 "Oscillator Enable" "Disabled"=FFFF "Enabled"=DFFF
+LIST2 FUSE1 "Oscillator" "RCO2RA6"=FFFF "HSPLL"=FEFF "ECO2RA6"=FDFF "ECO2 CLK Out"=FCFF "RC"=FBFF "HS"=FAFF "XT"=F9FF "LP"=F8FF
+LIST3 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST4 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST5 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST6 FUSE2 "Watchdog Postscale" "1:128"=FFFF "1:64"=FDFF "1:32"=FBFF "1:16"=F9FF "1:8"=F7FF "1:4"=F5FF "1:2"=F3FF "1:1"=F1FF
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE3 "CCP2 Mux" "Enabled"=FFFF "Disabled"=FEFF
+LIST9 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST10 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST11 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST12 FUSE5 "BOOT ROM Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST13 FUSE5 "ROM Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST14 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST15 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST16 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST17 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST18 FUSE6 "BOOT Table Write Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST19 FUSE6 "ROM Table Write Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST20 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST21 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST22 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST23 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST24 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST25 FUSE7 "BOOT Table Read Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST26 FUSE7 "ROM Table Read Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST27 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST28 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST29 FUSE7 "ROM Table Read Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+
 CHIPname=18F8621
 INCLUDE=Y
 KITSRUS.COM=0pin
@@ -5071,3 +6512,106 @@ LIST30 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabl
 LIST31 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
 LIST32 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
 LIST33 FUSE7 "ROM Table Read Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+
+CHIPname=18F8680
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=008000
+EEPROMsize=00000100
+FUSEblank=2F00 1F0F 8383 0085 C00F E00F 400F
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=0A00
+LIST1 FUSE1 "OSCSEN" "Disabled"=FFFF "Enabled"=DFFF
+LIST2 FUSE1 "Oscillator" "RC OSC2 RA6"=FFFF "HS PLL"=FEFF "EC OSC2RA6"=FDFF "EC OSC2RA6 PLL"= FCFF "RC OSC2RA6"=F7FF "HS PLL"=F6FF "EC OSC2RA6"=F5FF "EC OSC2/4"=F4FF "RC OSC2/4"=F3FF "HS"=F2FF "XT"=F1FF "LP"=F0FF
+LIST3 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST4 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST5 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST6 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST7 FUSE2 "Watchdog Postscale" "1:32768"=FFFF "1:16384"=FDFF "1:8192"=FBFF "1:4096"=F9FF "1:2048"=F7FF "1:1024"=F5FF "1:512"=F3FF "1:256"=F1FF "1:128"=EFFF "1:64"=EDFF "1:32"=EBFF "1:16"=E9FF "1:8"=E7FF "1:4"=E5FF "1:2"=E3FF "1:1"=E1FF
+LIST8 FUSE3 "WAIT" "Disabled"=FFFF "MEMCON"=FF7F
+LIST9 FUSE3 "Processor Mode" "Microcontroller"=FFFF "Microprocessor"=FFFE "Microprocessor Boot"=FFFD "Extended"=FFFC
+LIST10 FUSE3 "MCLRE" "Enabled"=FFFF "Disabled"=7FFF
+LIST11 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST12 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST13 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST14 FUSE5 "BOOT ROM Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST15 FUSE5 "ROM Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST16 FUSE5 "ROM Protect" "0400-7FFF Disabled"=FFFF "0400-7FFF Enabled"=FFFD
+LIST17 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST18 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-7FFF Enabled"=FFF7
+LIST19 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST20 FUSE6 "BOOT Table Write Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST21 FUSE6 "ROM Table Write Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST22 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST23 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=17FB
+LIST24 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=1FF7
+LIST25 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST26 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF
+LIST27 FUSE7 "BOOT Table Read Protect" "0000-07FF Disabled"=FFFF "0000-07FF Enabled"=BFFF
+LIST28 FUSE7 "ROM Table Read Protect" "0800-3FFF Disabled"=FFFF "0800-3FFF Enabled"=FFFE
+LIST29 FUSE7 "ROM Table Read Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST30 FUSE7 "ROM Table Read Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST31 FUSE7 "ROM Table Read Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+
+CHIPname=18F8720
+INCLUDE=Y
+KITSRUS.COM=0pin
+EraseMode=4
+FlashChip=Y
+PowerSequence=VccVpp1
+ProgramDelay=10
+ProgramFlag2=1
+PanelSizing=0
+CoreType=bit16_B
+ROMsize=004000
+EEPROMsize=00000100
+FUSEblank=2700 0F0F 0183 0085 C0FF E0FF 40FF
+CPwarn=N
+CALword=N
+BandGap=N
+ICSPonly=Y
+ChipID=0600
+LIST1 FUSE1 "Oscillator Enable" "Disabled"=FFFF "Enabled"=DFFF
+LIST2 FUSE1 "Oscillator" "RCO2RA6"=FFFF "HSPLL"=FEFF "ECO2RA6"=FDFF "ECO2 CLK Out"=FCFF "RC"=FBFF "HS"=FAFF "XT"=F9FF "LP"=F8FF
+LIST3 FUSE2 "Brownout Voltage" "2.0V"=FFFF "2.7V"=FFFB "4.2V"=FFF7 "4.5V"=FFF3
+LIST4 FUSE2 "Brownout Detect" "Enabled"=FFFF "Disabled"=FFFD
+LIST5 FUSE2 "Powerup Timer" "Disabled"=FFFF "Enabled"=FFFE
+LIST6 FUSE2 "Watchdog Postscale" "1:128"=FFFF "1:64"=FDFF "1:32"=FBFF "1:16"=F9FF "1:8"=F7FF "1:4"=F5FF "1:2"=F3FF "1:1"=F1FF
+LIST7 FUSE2 "Watchdog Timer" "Enabled"=FFFF "Disabled"=FEFF
+LIST8 FUSE3 "WAIT" "Disabled"=FFFF "MEMCON"=FF7F
+LIST9 FUSE3 "CCP2 Mux" "Enabled"=FFFF "Disabled"=FEFF
+LIST10 FUSE3 "PM1:0" "MicroController"=FFFF "Microprocessor"=FFFE "uProcessor with Boot"=FFFD "Extend uProcessor"=FFFC
+LIST11 FUSE4 "Background Debug" "Disabled"=FFFF "Enabled"=FF7F
+LIST12 FUSE4 "Low Voltage Program" "Enabled"=FFFF "Disabled"=FFFB
+LIST13 FUSE4 "Stack Overflow Reset" "Enabled"=FFFF "Disabled"=FFFE
+LIST14 FUSE5 "BOOT ROM Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST15 FUSE5 "ROM Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST16 FUSE5 "ROM Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST17 FUSE5 "ROM Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST18 FUSE5 "ROM Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST19 FUSE5 "ROM Protect" "10000-13FFF Disabled"=FFFF "10000-13FFF Enabled"=FFFE
+LIST20 FUSE5 "ROM Protect" "14000-17FFF Disabled"=FFFF "14000-17FFF Enabled"=FFFD
+LIST21 FUSE5 "ROM Protect" "18000-1BFFF Disabled"=FFFF "18000-1BFFF Enabled"=FFFB
+LIST22 FUSE5 "ROM Protect" "1C000-1FFFF Disabled"=FFFF "1C000-1FFFF Enabled"=FFF7
+LIST23 FUSE5 "EEPROM Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST24 FUSE6 "BOOT Table Write Protect" "0000-01FF Disabled"=FFFF "0000-01FF Enabled"=BFFF
+LIST25 FUSE6 "ROM Table Write Protect" "0200-3FFF Disabled"=FFFF "0200-3FFF Enabled"=FFFE
+LIST26 FUSE6 "ROM Table Write Protect" "4000-7FFF Disabled"=FFFF "4000-7FFF Enabled"=FFFD
+LIST27 FUSE6 "ROM Table Write Protect" "8000-BFFF Disabled"=FFFF "8000-BFFF Enabled"=FFFB
+LIST28 FUSE6 "ROM Table Write Protect" "C000-FFFF Disabled"=FFFF "C000-FFFF Enabled"=FFF7
+LIST29 FUSE6 "ROM Table Write Protect" "10000-13FFF Disabled"=FFFF "10000-13FFF Enabled"=FFFE
+LIST30 FUSE6 "ROM Table Write Protect" "14000-17FFF Disabled"=FFFF "14000-17FFF Enabled"=FFFD
+LIST31 FUSE6 "ROM Table Write Protect" "18000-1BFFF Disabled"=FFFF "18000-1BFFF Enabled"=FFFB
+LIST32 FUSE6 "ROM Table Write Protect" "1C000-1FFFF Disabled"=FFFF "1C000-1FFFF Enabled"=FFF7
+LIST33 FUSE6 "EEPROM Table Write Protect" "Disabled"=FFFF "Enabled"=7FFF
+LIST34 FUSE6 "CONFIG Table Write Protect" "Disabled"=FFFF "Enabled"=DFFF


### PR DESCRIPTION
Support for the microcontrollers listed below has been added to the `chipdata.cid` file. These chips were previously available in Microburn v141204 (Protocol P018) but were removed in Microburn v150807 (Protocol P18A).

- 16C66A
- 16C83
- 16F505
- 16F506
- 12F508
- 12F509
- 12F635
- 16F510
- 16F631-I
- 16F636
- 16F636-I
- 16F639
- 16F639-I
- 16F677-I
- 16F685-I
- 16F687-I
- 16F689-I
- 16F690-I
- 16F716
- 16LF873A
- 18F2515
- 18F2525
- 18F2585
- 18F2610
- 18F2620
- 18F2680
- 18F4515
- 18F4525
- 18F4585
- 18F4610
- 18F4620
- 18F4680
- 18F6585
- 18F6620
- 18F6680
- 18F6720
- 18F8585
- 18F8620
- 18F8680
- 18F8720