### PR TITLE
Run linter on 'README.md' and add instructions for enabling serial port access

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,44 +5,46 @@ This is complete rewrite of kitsrus_pic_programmer into Python 3 + bunch of fixe
 [![Tox tests](https://github.com/Salamek/picpro/actions/workflows/python-test.yml/badge.svg)](https://github.com/Salamek/picpro/actions/workflows/python-test.yml)
 
 ## Supported kitsrus programmers
-    * K128
-    * K149-A
-    * K149-B
-    * K150 (Tested)
-    
-See http://www.kitsrus.com/pic.html
-    
+
+* K128
+* K149-A
+* K149-B
+* K150 (Tested)
+
+See <http://www.kitsrus.com/pic.html>
 
 ## Installation
 
 ### PIP (pip3 on some distros)
 
-```
+```bash
 pip install picpro
 ```
 
 ### Repository
+
 You can also use these repositories maintained by me
+
 #### Debian and derivatives
 
 Add repository by running these commands
 
-```
-$ wget -O- https://repository.salamek.cz/deb/salamek.gpg | sudo tee /usr/share/keyrings/salamek-archive-keyring.gpg
-$ echo "deb     [signed-by=/usr/share/keyrings/salamek-archive-keyring.gpg] https://repository.salamek.cz/deb/pub all main" | sudo tee /etc/apt/sources.list.d/salamek.cz.list
+```bash
+wget -O- https://repository.salamek.cz/deb/salamek.gpg | sudo tee /usr/share/keyrings/salamek-archive-keyring.gpg
+echo "deb     [signed-by=/usr/share/keyrings/salamek-archive-keyring.gpg] https://repository.salamek.cz/deb/pub all main" | sudo tee /etc/apt/sources.list.d/salamek.cz.list
 ```
 
 And then you can install a package picpro
 
-```
-$ apt update && apt install picpro
+```bash
+apt update && apt install picpro
 ```
 
 #### Archlinux
 
-Add repository by adding this at end of file /etc/pacman.conf
+Add repository by adding this at end of file `/etc/pacman.conf`
 
-```
+```bash
 [salamek]
 Server = https://repository.salamek.cz/arch/pub/any
 SigLevel = Optional
@@ -50,14 +52,13 @@ SigLevel = Optional
 
 and then install by running
 
+```bash
+pacman -Sy picpro
 ```
-$ pacman -Sy picpro
-```
-
 
 ## Usage
 
-```
+```text
 Command details:
     program             Program PIC chip.
     verify              Verify PIC flash.
@@ -88,38 +89,46 @@ Options:
 
 ```
 
-### Program chip
+### Example: Program chip
 
 ```bash
 picpro program -p /dev/ttyUSB0 -i YOUR_HEX_FILE.hex -t 12F675
 ```
 
-### Verify chip program
+### Example: Verify chip program
 
 ```bash
 picpro verify -p /dev/ttyUSB0 -i YOUR_HEX_FILE.hex -t 12F675
 ```
 
-### Dump ROM as hex file
+### Example: Dump ROM as hex file
 
 ```bash
 picpro dump rom -p /dev/ttyUSB0 -o rom.hex -t 12F675
 ```
 
-### Dump EEPROM as hex file
+### Example: Dump EEPROM as hex file
 
 ```bash
 picpro dump eeprom -p /dev/ttyUSB0 -o eeprom.hex -t 12F675
 ```
 
-### Program chip via ISCP
+### Example: Program chip via ISCP
 
 ```bash
 picpro program -p /dev/ttyUSB0 -i YOUR_HEX_FILE.hex -t 12F675 --icsp
 ```
 
-### Program chip and override fuses provided from HEX file
+### Example: Program chip and override fuses provided from HEX file
 
 ```bash
 picpro program -p /dev/ttyUSB0 -i YOUR_HEX_FILE.hex -t 12F675 --fuse=FUSE_NAME:FUSE_VALUE --fuse=FUSE_NAME:FUSE_VALUE
+```
+
+## Enable serial port access
+
+To allow the user to access the serial ports (for some distros), run the following command:
+
+```bash
+sudo usermod -a -G dialout $USER
 ```


### PR DESCRIPTION
- Applied a linter to ensure proper formatting and consistency in 'README.md'.
- Added a new section, "Serial Port Access," with instructions for granting user access to serial ports using the `dialout` group.