### PR TITLE
Implement the use of the variable FlashChip to skip "Erasing chip"

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v1

--- a/picpro/ChipInfoEntry.py
+++ b/picpro/ChipInfoEntry.py
@@ -120,6 +120,7 @@ class ChipInfoEntry(IChipInfoEntry):
             program_retries=self.program_tries,
             over_program=self.over_program,
             fuse_blank=self.fuse_blank,
+            flash_chip=self.flash_chip,
         )
 
     def get_core_bits(self) -> int:

--- a/picpro/ProgrammingVars.py
+++ b/picpro/ProgrammingVars.py
@@ -17,3 +17,4 @@ class ProgrammingVars:
     program_retries: int
     over_program: int
     fuse_blank: List[int]
+    flash_chip: bool

--- a/picpro/bin/picpro.py
+++ b/picpro/bin/picpro.py
@@ -205,7 +205,6 @@ def chipinfo() -> None:
 
     print(json.dumps(data))
 
-
 @command()
 def hexinfo() -> None:
     pic_type = OPTIONS['<PIC_TYPE>']
@@ -267,7 +266,7 @@ def hexinfo() -> None:
             print("{:s}{:s}{{ first: 0x{:08X}, last: 0x{:08X}, length: 0x{:08X} }}".format(INDENT, INLIST, s[0], s[1] - 1, s[1] - s[0]))
     print("")
 
-    # if self.chip_info.programming_vars.rom_size < word_count:  # type: ignore
+    #if self.chip_info.programming_vars.rom_size < word_count:  # type: ignore
     #    raise InvalidValueError('Data too large for PIC ROM {} > {}'.format(word_count, chip_info.programming_vars.rom_size))
     return None
 
@@ -589,7 +588,7 @@ def program_pic(
             no_of_zeros = pic_rom_data.count(b'\x00')
             pic_rom_data_len = len(pic_rom_data)
             if chip_info.programming_vars.flag_calibration_value_in_rom:
-                is_maybe_locked = pic_rom_data_len - 2 == no_of_zeros
+                is_maybe_locked = pic_rom_data_len -2 == no_of_zeros
             else:
                 is_maybe_locked = pic_rom_data_len == no_of_zeros
 

--- a/picpro/bin/picpro.py
+++ b/picpro/bin/picpro.py
@@ -181,10 +181,14 @@ def erase() -> None:
     if not programmer_common_data:
         return
 
-    _, protocol_interface = programmer_common_data
-    print('Erasing chip...')
-    protocol_interface.erase_chip()
-    print('Done!')
+    chip_info, protocol_interface = programmer_common_data
+
+    if chip_info.programming_vars.flash_chip:
+        print('Erasing chip...')
+        protocol_interface.erase_chip()
+        print('Done!')
+    else:
+        print('This chip is not erasable.')
 
 
 @command()
@@ -548,10 +552,11 @@ def program_pic(
 
         if is_program:
             # Write ROM, EEPROM, ID and fuses
-            print('Erasing chip.')
-            if not protocol_interface.erase_chip():
-                print('Erasure failed.')
-                return False
+            if chip_info.programming_vars.flash_chip:
+                print('Erasing chip.')
+                if not protocol_interface.erase_chip():
+                    print('Erasure failed.')
+                    return False
 
             protocol_interface.cycle_programming_voltages()
 

--- a/picpro/bin/picpro.py
+++ b/picpro/bin/picpro.py
@@ -205,6 +205,7 @@ def chipinfo() -> None:
 
     print(json.dumps(data))
 
+
 @command()
 def hexinfo() -> None:
     pic_type = OPTIONS['<PIC_TYPE>']
@@ -266,7 +267,7 @@ def hexinfo() -> None:
             print("{:s}{:s}{{ first: 0x{:08X}, last: 0x{:08X}, length: 0x{:08X} }}".format(INDENT, INLIST, s[0], s[1] - 1, s[1] - s[0]))
     print("")
 
-    #if self.chip_info.programming_vars.rom_size < word_count:  # type: ignore
+    # if self.chip_info.programming_vars.rom_size < word_count:  # type: ignore
     #    raise InvalidValueError('Data too large for PIC ROM {} > {}'.format(word_count, chip_info.programming_vars.rom_size))
     return None
 
@@ -588,7 +589,7 @@ def program_pic(
             no_of_zeros = pic_rom_data.count(b'\x00')
             pic_rom_data_len = len(pic_rom_data)
             if chip_info.programming_vars.flag_calibration_value_in_rom:
-                is_maybe_locked = pic_rom_data_len -2 == no_of_zeros
+                is_maybe_locked = pic_rom_data_len - 2 == no_of_zeros
             else:
                 is_maybe_locked = pic_rom_data_len == no_of_zeros
 

--- a/tests/test_ChipInfoReader.py
+++ b/tests/test_ChipInfoReader.py
@@ -78,7 +78,8 @@ def test_get_chip_programing_vars(chip_data_path: str) -> None:
         erase_mode=3,
         program_retries=1,
         over_program=0,
-        fuse_blank=[16383, 16383]
+        fuse_blank=[16383, 16383],
+        flash_chip=True
     )
 
     chip_info = chip_info_reader.get_chip('16f737')

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = lint, py38, py39, py310, py311, py312, py313
 
 [gh-actions]
 python =
-    3.9: py39, lint
+    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
Implement the use of the variable FlashChip to skip "Erasing chip".

If validated and confirmed to be functioning as intended, this commit:
- Fully resolves issue https://github.com/Salamek/picpro/issues/29
- Partially addresses issue https://github.com/Salamek/picpro/issues/4, contributing to its overall resolution.