### PR TITLE
Implement the use of the variable FlashChip to skip "Erasing chip"

### DIFF
--- a/picpro/ChipInfoEntry.py
+++ b/picpro/ChipInfoEntry.py
@@ -120,6 +120,7 @@ class ChipInfoEntry(IChipInfoEntry):
             program_retries=self.program_tries,
             over_program=self.over_program,
             fuse_blank=self.fuse_blank,
+            flash_chip=self.flash_chip,
         )
 
     def get_core_bits(self) -> int:

--- a/picpro/ProgrammingVars.py
+++ b/picpro/ProgrammingVars.py
@@ -17,3 +17,4 @@ class ProgrammingVars:
     program_retries: int
     over_program: int
     fuse_blank: List[int]
+    flash_chip: bool

--- a/picpro/bin/picpro.py
+++ b/picpro/bin/picpro.py
@@ -181,10 +181,14 @@ def erase() -> None:
     if not programmer_common_data:
         return
 
-    _, protocol_interface = programmer_common_data
-    print('Erasing chip...')
-    protocol_interface.erase_chip()
-    print('Done!')
+    chip_info, protocol_interface = programmer_common_data
+
+    if chip_info.programming_vars.flash_chip:
+        print('Erasing chip...')
+        protocol_interface.erase_chip()
+        print('Done!')
+    else:
+        print('This chip is not erasable.')
 
 
 @command()
@@ -548,10 +552,11 @@ def program_pic(
 
         if is_program:
             # Write ROM, EEPROM, ID and fuses
-            print('Erasing chip.')
-            if not protocol_interface.erase_chip():
-                print('Erasure failed.')
-                return False
+            if chip_info.programming_vars.flash_chip:
+                print('Erasing chip.')
+                if not protocol_interface.erase_chip():
+                    print('Erasure failed.')
+                    return False
 
             protocol_interface.cycle_programming_voltages()
 

--- a/tests/test_ChipInfoReader.py
+++ b/tests/test_ChipInfoReader.py
@@ -78,7 +78,8 @@ def test_get_chip_programing_vars(chip_data_path: str) -> None:
         erase_mode=3,
         program_retries=1,
         over_program=0,
-        fuse_blank=[16383, 16383]
+        fuse_blank=[16383, 16383],
+        flash_chip=True
     )
 
     chip_info = chip_info_reader.get_chip('16f737')

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = lint, py38, py39, py310, py311, py312, py313
 
 [gh-actions]
 python =
-    3.9: py39, lint
+    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
Implement the use of the variable FlashChip to skip "Erasing chip".

If validated and confirmed to be functioning as intended, this commit:
- Fully resolves issue https://github.com/Salamek/picpro/issues/29
- Partially addresses issue https://github.com/Salamek/picpro/issues/4, contributing to its overall resolution.